### PR TITLE
Revert undesired side-effect

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ It lists every namespace and table in your Lakehouse—along with each table’s
 
 Lakevision is built with **pyiceberg**, a `FastAPI` backend, and a `SvelteKit` frontend, keeping other dependencies to a minimum.
 
-![Lakevision screenshot](https://github.com/user-attachments/assets/7c71d61f-ffea-497a-97d0-451dec662b96)
+https://github.com/user-attachments/assets/7c71d61f-ffea-497a-97d0-451dec662b96
 
 ## Features
 


### PR DESCRIPTION
by wrapping the link as documented in GH, the video does not show embedded anymore; instead, just a link is displayed.

![image](https://github.com/user-attachments/assets/4256f3ea-c172-4219-a64e-8daa68e06ee2)
