### PR TITLE
fix: added extra checks for make commands sample-catalog and init-fe

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,8 +49,14 @@ run-be:
 clean-be:
 	rm -rf be/.venv
 
+.PHONY: sample-catalog-deps
+sample-catalog-deps:
+	$(CHECK_VENV)
+	@echo "📚 Ensuring SQLite extras for PyIceberg are available (sample only)..."
+	@cd be && ../$(VENV_PYTHON) -m pip install "pyiceberg[sql-sqlite]"
+
 .PHONY: sample-catalog
-sample-catalog:
+sample-catalog: sample-catalog-deps
 	$(CHECK_VENV)
 	@echo "📦 Creating sample in-memory Iceberg catalog with demo data..."
 	cd be && set -a && source ../.env && set +a && PYTHONPATH=app ../$(VENV_PYTHON) ../scripts/load_sample_data.py
@@ -62,7 +68,19 @@ clean-catalog:
 
 # --- Frontend ---
 
-init-fe:
+.PHONY: check-npm
+check-npm:
+	@command -v npm >/dev/null 2>&1 || { \
+		echo "❌ npm is required but not installed."; \
+		echo ""; \
+		echo "Install Node.js (which includes npm):"; \
+		echo "  macOS:   brew install node"; \
+		echo "  Ubuntu:  sudo apt-get update && sudo apt-get install -y nodejs npm"; \
+		echo "  Fedora:  sudo dnf install -y nodejs npm"; \
+		echo "  Windows: Download from https://nodejs.org/"; \
+		exit 1; }
+
+init-fe: check-npm
 	cd fe && npm install
 
 prepare-fe-env:


### PR DESCRIPTION
A user reported two issues when trying to setup the project for the first time:
- a missing dependency to build the in-memory sample catalog
- npm is assumed to be installed and no checks are performed

To validate the fix for `make init-fe` if you already have node, you can run it like this `PATH="/usr/bin:/bin" make init-fe`